### PR TITLE
Use the nowdoc syntax instead of heredoc

### DIFF
--- a/content/1.docs/3.integrations/0.gutenberg.md
+++ b/content/1.docs/3.integrations/0.gutenberg.md
@@ -85,38 +85,39 @@ add_action('enqueue_block_editor_assets', function() {
     $screen = get_current_screen();
     if (is_admin() && $screen->is_block_editor()) {
         add_action('admin_head', function() {
-            echo <<<JS
-                <script>
-                    (async () => {
-                    // Select all external stylesheets
-                    const links = Array.from(document.querySelectorAll('link[rel="stylesheet"]'));
-                    for (const link of links) {
-                        const href = link.href;
-                        try {
-                            // Fetch the CSS content
-                            const response = await fetch(href);
-                            if (!response.ok) {
-                                console.error(`Failed to fetch stylesheet: ${href}`);
-                                continue;
-                            }
-                            const css = await response.text();
-                            // Wrap the CSS in @layer base
-                            const wrappedCSS = `@layer base {\n${css}\n}`;
-                            // Create a <style> element to inject the wrapped CSS
-                            const style = document.createElement('style');
-                            style.textContent = wrappedCSS;
-                            // Replace the <link> tag with the <style> tag
-                            link.parentNode.replaceChild(style, link);
-                        } catch (error) {
-                            console.error(`Error processing stylesheet: ${href}`, error);
-                        }
-                    }
-                })();
-                </script>
-            JS;
+            echo <<<'JS'
+<script>
+    (async () => {
+        // Select all external stylesheets
+        const links = Array.from(document.querySelectorAll('link[rel="stylesheet"]'));
+        for (const link of links) {
+            const href = link.href;
+            try {
+                // Fetch the CSS content
+                const response = await fetch(href);
+                if (!response.ok) {
+                    console.error(`Failed to fetch stylesheet: ${href}`);
+                    continue;
+                }
+                const css = await response.text();
+                // Wrap the CSS in @layer base
+                const wrappedCSS = `@layer base {\n${css}\n}`;
+                // Create a <style> element to inject the wrapped CSS
+                const style = document.createElement('style');
+                style.textContent = wrappedCSS;
+                // Replace the <link> tag with the <style> tag
+                link.parentNode.replaceChild(style, link);
+            } catch (error) {
+                console.error(`Error processing stylesheet: ${href}`, error);
+            }
+        }
+    })();
+</script>
+JS;
         }, 1_000_001);
     }
 });
+
 ```
 
 Then, in your WindPress `main.css` file, adjust the content to include the reset:


### PR DESCRIPTION
This prevents PHP variable interpolation in the JavaScript code that was causing the Gutenburg FSE editor to break.